### PR TITLE
shell/shell: fix double echo backspace issue

### DIFF
--- a/shell/shell/shell.c
+++ b/shell/shell/shell.c
@@ -323,7 +323,7 @@ static void shell(void) {
         line_buff[count] = c;
         count++;
       }
-      if (__echo) {
+      if (__echo && c != DELETE && c != BACK_SPACE) {
         __write_char__(c);
       }
     } else {


### PR DESCRIPTION
>```c
>static void delete(void) {
>  __write_char__(BACK_SPACE);
>  __write_char__(SPACE);
>  __write_char__(BACK_SPACE);
>}
>```

The `delete` function has finally sent a BACK_ SPACE, in this case, there is no need to echo BACK_SPACE again